### PR TITLE
Check for all source packages in a mirror.

### DIFF
--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -13,7 +13,7 @@ class Reprepro2AptlyFilter():
     def convert(self, filter_str):
         # remove begin/end whitespaces
         r_str = filter_str.lstrip()
-        # Package menas nothing as filter. Could be Name or empty.
+        # Package is not a valid Aptly filter. Could be Name or empty.
         r_str = r_str.replace('Package', 'Name')
         # Do not use equal symbols, just remove
         r_str = r_str.replace('% =', '')

--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -75,8 +75,9 @@ class Aptly():
             if len(source.split(' ')) > 1:
                 source = source.split(' ')[0]
             packages_by_source[source].add(package)
-        source_packages = check_output(['aptly', aptly_type.value, 'search', '-format={{.Package}}', name, '$PackageType (= source)']).splitlines()
+        source_packages = check_output(['aptly', aptly_type.value, 'search', '-format={{.Package}}', name, '$PackageType (= source)']).decode('utf-8').splitlines()
         result = True
+
         for source in packages_by_source:
             if source not in source_packages:
                 print(f"Source package '{source}' is missing for packages: {', '.join(packages_by_source[source])}")

--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -67,6 +67,9 @@ class Aptly():
 
         packages_by_source = defaultdict(set)
         for line in check_output(['aptly', aptly_type.value, 'search', '-format={{.Package}}::{{.Source}}', name, '$PackageType (= deb)']).splitlines():
+            # ignore empty entries with 'no value'
+            if 'no value' in line.decode('utf-8'):
+                continue
             package, source = line.decode('utf-8').split('::')
             # Source field may include a parenthesized version which we'll ignore for now. e.g. `pcl (1.11.1+dfsg-1)`
             if len(source.split(' ')) > 1:

--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -15,8 +15,8 @@ class Reprepro2AptlyFilter():
         r_str = filter_str.lstrip()
         # Package is not a valid Aptly filter. Could be Name or empty.
         r_str = r_str.replace('Package', 'Name')
-        # Do not use equal symbols, just remove
-        r_str = r_str.replace('% =', '')
+        # Aptly filters use (= value) for exact matches rather than (% =value)
+        r_str = r_str.replace('% =', '= ')
         return r_str
 
 

--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -162,7 +162,7 @@ class UpdaterManager():
 
     def __create_aptly_mirror(self, distribution):
         assert(self.config)
-        self.__log(f"Creating aplty mirror for {distribution}")
+        self.__log(f"Creating aptly mirror for {distribution}")
         mirror_name = self.__get_mirror_name(distribution)
         self.aptly.run(['mirror', 'create', '-with-sources',
                         f"-architectures={','.join(self.config.architectures)}",

--- a/scripts/aptly/aptly_importer.py
+++ b/scripts/aptly/aptly_importer.py
@@ -113,7 +113,7 @@ class Aptly():
             if 'no results' in result.stderr.decode('utf-8'):
                 return []
             else:
-                self.__error('get_source_packages method', result.stderr)
+                self.__error('get_source_packages method', result.stderr.decode('utf-8'))
 
     def get_snapshots_from_mirror(self, mirror_name):
         result = []

--- a/scripts/aptly/aptly_importer_TEST.py
+++ b/scripts/aptly/aptly_importer_TEST.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 import unittest
 
-
 class TestYamlConfiguration(unittest.TestCase):
     def test_non_existsing_file(self):
         with self.assertRaises(SystemExit):
@@ -128,7 +127,7 @@ class TestUpdaterManager(unittest.TestCase):
         self.assertTrue(manager.run())
         self.__assert_expected_repos_mirrors()
 
-    def test_basic_example_creation_existsing_repo(self):
+    def test_basic_example_creation_existing_repo(self):
         self.__setup__(['focal', 'groovy'])
         [self.__add_repo(name) for name in self.expected_repos_test_name]
         manager = aptly_importer.UpdaterManager('test/example.yaml',


### PR DESCRIPTION
This updates the source package checking function to fetch all deb
packages in the repository with their source package name, then check
that list of source packages against all source packages in the
repository.

With this change there are now new failures since the source check is
now more stricter _and_ because when a search query is empty aptly
returns 1 instead of 0 so we may have to move away from relying on
check_output for easy access to aptly query output.


This accidentally brings in a few nitpick / suggestion commits which you can take or leave. The big one is 
9d17d6d.